### PR TITLE
Broken "list ." command

### DIFF
--- a/trepan/processor/cmdlist.py
+++ b/trepan/processor/cmdlist.py
@@ -70,7 +70,7 @@ def parse_list_cmd(proc, args, listsize=10):
             if not location:
                 return INVALID_PARSE_LIST
             last     = location.line_number
-            first    = max(1, last - listsize)
+            first    = max(1, last - listsize + 1)
             return location.path, first, last
         elif isinstance(list_range.first, int):
             first    = list_range.first
@@ -81,7 +81,7 @@ def parse_list_cmd(proc, args, listsize=10):
             last     = location.line_number
             if last < first:
                 # Treat as a count rather than an absolute location
-                last = first + last
+                last = first + last - 1
             return location.path, first, last
         else:
             # First is location. Last may be empty or a number
@@ -98,10 +98,10 @@ def parse_list_cmd(proc, args, listsize=10):
                 assert last[0] == '+'
                 last = first + int(last[1:])
             elif not last:
-                last = first + listsize
+                last = first + listsize - 1
             elif last < first:
                 # Treat as a count rather than an absolute location
-                last = first + last
+                last = first + last - 1
 
             return location.path, first, last
         pass

--- a/trepan/processor/cmdlist.py
+++ b/trepan/processor/cmdlist.py
@@ -30,7 +30,8 @@ def parse_list_cmd(proc, args, listsize=10):
     if text in frozenset(('', '.', '+', '-')):
         if text == '.':
             location = resolve_location(proc, '.')
-            return location.path, location.line_number, listsize
+            filename = location.path
+            first = location.line_number - (listsize // 2)
         else:
             if proc.list_lineno is None:
                 proc.errmsg("Don't have previous list location")


### PR DESCRIPTION
dd81b32 is a simple modification that fixes the behaviour of "list .".  

While I was at it, with dd81b32 I also fixed the number of lines printed as a result of commands such as "list 25," and similar.  According to my understanding the number of lines printed when one of the range limits is left blank should always be "listsize" (10 by default), while in many cases the number was actually 11.
 