### PR TITLE
Fix fifo client

### DIFF
--- a/trepan/inout/fifoclient.py
+++ b/trepan/inout/fifoclient.py
@@ -78,10 +78,10 @@ class FIFOClient(DebuggerInOutBase):
                 raise IOError("input FIFO %s doesn't exist" %
                               self.in_name)
             else:
-                raise IOError("output FIFO %s is not readable" %
+                raise IOError("input FIFO %s is not readable" %
                               self.out_name)
-            self.state     = 'active'
             pass
+        self.state     = 'active'
         return
 
     def read_msg(self):


### PR DESCRIPTION
Currently, it always fails with "readline called in state: disconnected".