### PR TITLE
Fix the return tuples for parse_break_cmd

### DIFF
--- a/trepan/processor/command/continue.py
+++ b/trepan/processor/command/continue.py
@@ -52,7 +52,7 @@ See also:
     def run(self, args):
         if len(args) > 1:
             # FIXME: DRY this code. Better is to hook into tbreak.
-            func, filename, lineno, condition = parse_break_cmd(self.proc, args)
+            func, filename, lineno, condition, offset = parse_break_cmd(self.proc, args)
             if not set_break(self, func, filename, lineno, condition, True, args):
                 return False
         self.core.step_events = None  # All events

--- a/trepan/processor/command/tbreak.py
+++ b/trepan/processor/command/tbreak.py
@@ -66,7 +66,7 @@ See also:
     complete = complete_break_linenumber
 
     def run(self, args):
-        func, filename, lineno, condition = parse_break_cmd(self.proc, args)
+        func, filename, lineno, condition, offset = parse_break_cmd(self.proc, args)
         if not (func == None and filename == None):
             set_break(self, func, filename, lineno, condition,
                       True, args)


### PR DESCRIPTION
looks like a couple of modules were missed when you added the offset
to the returned tuple for parse_break_cmd

the returned tuples in continue.py and tbreak.py are misssing offset

the returned tuples in break.py and line.py are ok.

causes commands like "c 20" to fail when I use trepan3k 1.2.0

(I tried to minimize code changes, so I didn't try to make it DRY)