### PR TITLE
tcp.api stop() flips parameters of isinstance

### DIFF
--- a/trepan/api.py
+++ b/trepan/api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#   Copyright (C) 2008-2009, 2013-2017, 2019-2020 Rocky Bernstein <rocky@gnu.org>
+#   Copyright (C) 2008-2009, 2013-2017, 2019-2021 Rocky Bernstein <rocky@gnu.org>
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -241,7 +241,7 @@ dictionary that gets fed to trepan.Debugger.core.start().
 
 
 def stop(opts=None):
-    if isinstance( Mdebugger.debugger_obj, Trepan):
+    if isinstance(Mdebugger.debugger_obj, Trepan):
         return Mdebugger.debugger_obj.stop(opts)
     return None
 


### PR DESCRIPTION
`isinstance(Trepan, Mdebugger.debugger_obj)` -> `isinstance( Mdebugger.debugger_obj, Trepan)`

Fixes #32